### PR TITLE
Add support for proxy auth

### DIFF
--- a/lib/node-get/node-get.js
+++ b/lib/node-get/node-get.js
@@ -37,6 +37,8 @@ function Get(options) {
         this.headers = default_headers;
         if (process.env.HTTP_PROXY) {
             this.proxy = url.parse(process.env.HTTP_PROXY);
+            this.headers['proxy-authorization'] =
+                'Basic ' + new Buffer(this.proxy.auth).toString('base64');
         } else {
             this.proxy = {};
         }
@@ -52,6 +54,8 @@ function Get(options) {
         this.timeout = 'timeout' in options ? options.timeout : 10000;
         if (!this.no_proxy && process.env.HTTP_PROXY) {
             this.proxy = url.parse(process.env.HTTP_PROXY);
+            this.headers['proxy-authorization'] =
+                'Basic ' + new Buffer(this.proxy.auth).toString('base64');
         } else {
             this.proxy = {};
         }


### PR DESCRIPTION
Sets `proxy-authorization` headers when proxy done.

On a side note, it looks like is Travis is complaining about the previous commit (mocha tests) not working in 0.4. Not sure if this affects publishing http://travis-ci.org/#!/developmentseed/node-get/jobs/1818201
