### PR TITLE
Make HTTP agent configurable

### DIFF
--- a/lib/node-get/node-get.js
+++ b/lib/node-get/node-get.js
@@ -65,6 +65,7 @@ function Get(options) {
         } else {
             this.proxy = {};
         }
+        this.agent = options.agent || undefined;
     }
 }
 
@@ -89,6 +90,7 @@ Get.prototype.request = function(callback) {
     // TODO: should pronode-getxies support HTTPS?
     if (this.uri_o.protocol == 'https:') {
         return https.request({
+            agent: this.agent,
             host: this.uri_o.hostname,
             port: 443,
             headers: this.headers,
@@ -100,6 +102,7 @@ Get.prototype.request = function(callback) {
         }, callback);
     } else {
         return http.request({
+            agent: this.agent,
             port: this.proxy.port || this.uri_o.port || 80,
             host: this.proxy.hostname || this.uri_o.hostname,
             headers: this.headers,


### PR DESCRIPTION
Allows you to provide your own HTTP agent for node-get to use for requests.
