### PR TITLE
Close the original connection when we're done with it

### DIFF
--- a/lib/node-get/node-get.js
+++ b/lib/node-get/node-get.js
@@ -143,12 +143,14 @@ Get.prototype.perform = function(callback, times) {
             } else {
                 this.uri = url.resolve(this.uri, response.headers.location);
             }
+            response.connection.end();
             this.perform(callback, times + 1);
             return;
         } else if (response.statusCode >= 400) {
             // failure
             var err = new Error('Server returned HTTP ' + response.statusCode);
             err.status = response.statusCode;
+            response.connection.end();
             return callback.call(this, err, response);
         } else {
             // success
@@ -239,6 +241,7 @@ Get.prototype.asString = function(callback) {
             case 'application':
             case 'image':
             case 'video':
+                response.connection.end();
                 return callback(new Error("Can't download binary file as string"));
             default:
                 // TODO: respect Content-Transfer-Encoding header


### PR DESCRIPTION
I have no idea if this is actually the right fix or not, but the problem I am seeing is that (at least with node 0.10) failure to close the underlying connection when doing a redirect causes the timeout to fire, resulting in the failure of tests later on.

Similarly failing to close the connection when `asString` aborts because it finds a binary file causes a "socket hung up" exception at some later point.
