### PR TITLE
Node v0.10.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - 0.4
   - 0.6
+  - 0.8
+  - 0.10

--- a/lib/node-get/node-get.js
+++ b/lib/node-get/node-get.js
@@ -131,6 +131,7 @@ Get.prototype.perform = function(callback, times) {
 
     var clientrequest = this.request(function handleClientRequest(response, err) {
         if (err) return callback.call(this, err, null);
+        response.resume();
         if (response.statusCode >= 300 &&
             response.statusCode < 400 &&
             response.headers.location) {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "main": "./lib/node-get/index.js",
     "keywords": ["http", "client", "request", "get"],
     "url": "http://github.com/developmentseed/node-get",
-    "repositories": [{
+    "repository": {
         "type": "git",
         "url": "git://github.com/developmentseed/node-get.git"
-    }],
+    },
     "author": "Tom MacWright <macwright@gmail.com>",
     "contributors": [
         "Konstantin Käfer <kkaefer@gmail.com>"


### PR DESCRIPTION
All tests are passing with both:
- node v0.10.16 / OS X
- node v0.8.25 / OS X

Unblocks https://github.com/mapbox/node-tilejson/pull/7 and https://github.com/mapbox/tilelive-s3/pull/8
